### PR TITLE
check and permutation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,3 +18,4 @@ Imports: vars, expm, reshape2, ggplot2, copula, clue, pbapply, steadyICA, tsDyn,
 License: GPL (>= 2)
 LazyData: TRUE
 RoxygenNote: 6.0.1
+Suggests: testthat

--- a/R/permutation.R
+++ b/R/permutation.R
@@ -1,8 +1,40 @@
-permutation = function(mat){
-  expP <- unique(expand.grid(1:ncol(mat), 1:ncol(mat), 1:ncol(mat)))
-  combinations = expP[apply(expP, 1, function(a) length(unique(abs(a)))==ncol(mat))==TRUE ,]
+# computes all permutations of the columns of a matrix
+# returns a list of matrices
+permutation <- function(mat) {
+  permutations <- permute_vector(1:ncol(mat))
 
-  return(lapply(1:nrow(combinations), function(x){
-    mat[, unlist(combinations[x,])]
-  }))
+  res_list <- list()
+  for (i in 1:ncol(permutations)) {
+    res_list[[i]] <- mat[, permutations[, i, drop = TRUE], drop = FALSE]
+  }
+  return(res_list)
+}
+
+# calculate all permutations of a vector x
+# naiive recursive implementation.
+# @param x a vector
+# @return matrix; each column is one unqiue permutation of x
+permute_vector <- function(x) {
+  n <- length(x)
+  num_permutation <- factorial(n)
+
+  if (n == 1) { # base case
+    return(as.matrix(x))
+  } else {
+    num_sub_permutation <- factorial(n - 1)
+    res <- matrix(0.0, nrow = n, ncol = num_permutation)
+    for (i in 1:n) {
+      # swap first entry in x with i-th one
+      y <- x
+      tmp <- y[1]
+      y[1] <- y[i]
+      y[i] <- tmp
+
+      # calculate all permutations of y[2:n]
+      col_idx <- (i-1) * num_sub_permutation + seq(1:num_sub_permutation)
+      res[1, col_idx] <- y[1]
+      res[2:n, col_idx] <- permute_vector(y[2:n])
+    }
+    return(res)
+  }
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(svars)
+
+test_check("svars")

--- a/tests/testthat/test-permutation.R
+++ b/tests/testthat/test-permutation.R
@@ -43,5 +43,5 @@ test_that("3x3 permutation works", {
 })
 
 test_that("1x1 permutation works", {
-  expect_equal(as.matrix(1), permutation(as.matrix(1)))
+  expect_equal(list(as.matrix(1)), permutation(as.matrix(1)))
 })


### PR DESCRIPTION
This should fix the issue that `R CMD check` did not run the tests specified as `testthat` tests. Thus, travis has also ignored these tests. Furthermore, `svars:::permutation` is now working with 1x1 and 2x2 matrices.